### PR TITLE
for discord webhook, delete previous messages upon creation + show earning speeds of listed plots

### DIFF
--- a/src/discord/webhookdata.ts
+++ b/src/discord/webhookdata.ts
@@ -1,5 +1,6 @@
 import { Client, ColorResolvable, MessageEmbed } from 'discord.js';
 import {
+  earningSpeedsArr,
   getPrice,
   latestFloorPrice,
   latestFloorPriceUpgraded,
@@ -40,12 +41,18 @@ const sectionsData: SectionData[] = [
   {
     colour: '#be744b',
     authorIconUrl: 'https://solarsystem.nasa.gov/internal_resources/3841/',
-    authorName: 'Floor Plot Data',
+    authorName: 'Floor Plot Prices',
   },
   {
     colour: '#dddc45',
     authorIconUrl: 'https://meta.marscolony.io/1.png',
-    authorName: 'Floor Plot Buying Comparison',
+    authorName: 'Floor Plots Buying Comparison',
+  },
+  {
+    colour: '#02628c',
+    authorIconUrl:
+      'https://img.icons8.com/external-filled-outline-wichaiwi/344/external-count-election-filled-outline-wichaiwi.png',
+    authorName: 'Listed Plots Earning Speed Comparison',
   },
   {
     colour: '#ffffff',
@@ -115,12 +122,13 @@ const getEmbedMessage = async (): Promise<MessageEmbed[]> => {
   const priceData = await getPrice();
   const statsData = await getCLNYStats();
 
+  const priceDataSections = priceData.split('\n\n');
   return [
     new MessageEmbed()
       .setDescription(
         priceCLNYperONE === 0 || priceONEperUSD === 0 || priceCLNYperUSD === 0
           ? 'Fetching prices...'
-          : priceData.split('\n\n')[0]
+          : priceDataSections[0]
       )
       .setAuthor({
         name: sectionsData[0].authorName,
@@ -134,7 +142,7 @@ const getEmbedMessage = async (): Promise<MessageEmbed[]> => {
           latestFloorPriceUpgraded === 0 ||
           numUpgradedPlots === 0
           ? 'Fetching plots data...'
-          : priceData.split('\n\n')[1]
+          : priceDataSections[1]
       )
       .setAuthor({
         name: sectionsData[1].authorName,
@@ -145,7 +153,7 @@ const getEmbedMessage = async (): Promise<MessageEmbed[]> => {
       .setDescription(
         latestFloorPrice === 0 || latestFloorPriceUpgraded === 0
           ? 'Fetching plot comparison data...'
-          : priceData.split('\n\n')[2]
+          : priceDataSections[2]
       )
       .setAuthor({
         name: sectionsData[2].authorName,
@@ -154,9 +162,9 @@ const getEmbedMessage = async (): Promise<MessageEmbed[]> => {
       .setColor(sectionsData[2].colour),
     new MessageEmbed()
       .setDescription(
-        totalTransactionValueCached === 0 || numSoldCached === 0
-          ? 'Fetching transactions data...'
-          : priceData.split('\n\n')[3]
+        earningSpeedsArr.length === 0
+          ? 'Fetching listed plots earning speeds...'
+          : priceDataSections[3]
       )
       .setAuthor({
         name: sectionsData[3].authorName,
@@ -164,11 +172,22 @@ const getEmbedMessage = async (): Promise<MessageEmbed[]> => {
       })
       .setColor(sectionsData[3].colour),
     new MessageEmbed()
-      .setDescription(statsData)
+      .setDescription(
+        totalTransactionValueCached === 0 || numSoldCached === 0
+          ? 'Fetching transactions data...'
+          : priceDataSections[4]
+      )
       .setAuthor({
         name: sectionsData[4].authorName,
         iconURL: sectionsData[4].authorIconUrl,
       })
       .setColor(sectionsData[4].colour),
+    new MessageEmbed()
+      .setDescription(statsData)
+      .setAuthor({
+        name: sectionsData[5].authorName,
+        iconURL: sectionsData[5].authorIconUrl,
+      })
+      .setColor(sectionsData[5].colour),
   ];
 };

--- a/src/discordBotInit.ts
+++ b/src/discordBotInit.ts
@@ -68,9 +68,9 @@ discordClient.on('messageCreate', (message: Message) => {
           DISCORD_REALTIME_CHANNEL_WEBHOOK_ID,
           DISCORD_REALTIME_CHANNEL_WEBHOOK_TOKEN
         );
-        const msges = await message.channel.messages.fetch();
 
-        // delete all except one
+        // in realtime webhook (should have just 1 updated message), delete all except current message
+        const msges = await message.channel.messages.fetch();
         for (const msgEntry of msges.entries()) {
           const [msgId, msg] = msgEntry;
           if (msgId !== messageId) {

--- a/src/discordBotInit.ts
+++ b/src/discordBotInit.ts
@@ -2,7 +2,12 @@ import 'reflect-metadata';
 import { Intents, Interaction, Message } from 'discord.js';
 import { Client } from 'discordx';
 import { dirname, importx } from '@discordx/importer';
-import { DISCORD_BOT_TOKEN, DISCORD_REALTIME_CHANNEL_ID } from './secrets';
+import {
+  DISCORD_BOT_TOKEN,
+  DISCORD_REALTIME_CHANNEL_ID,
+  DISCORD_REALTIME_CHANNEL_WEBHOOK_ID,
+  DISCORD_REALTIME_CHANNEL_WEBHOOK_TOKEN,
+} from './secrets';
 import { updateRealtimeChannelPriceData } from './discord/webhookdata';
 
 const discordClient = new Client({
@@ -51,6 +56,31 @@ discordClient.on('interactionCreate', (interaction: Interaction) => {
 
 discordClient.on('messageCreate', (message: Message) => {
   discordClient.executeCommand(message);
+  const messageId = message.id;
+
+  const deletePrevWebhookMsges = async () => {
+    if (message.channelId === DISCORD_REALTIME_CHANNEL_ID) {
+      const realtimeChannel = discordClient.channels.cache.get(
+        DISCORD_REALTIME_CHANNEL_ID
+      );
+      if (realtimeChannel) {
+        const webhook = await realtimeChannel.client.fetchWebhook(
+          DISCORD_REALTIME_CHANNEL_WEBHOOK_ID,
+          DISCORD_REALTIME_CHANNEL_WEBHOOK_TOKEN
+        );
+        const msges = await message.channel.messages.fetch();
+
+        // delete all except one
+        for (const msgEntry of msges.entries()) {
+          const [msgId, msg] = msgEntry;
+          if (msgId !== messageId) {
+            webhook.deleteMessage(msg);
+          }
+        }
+      }
+    }
+  };
+  deletePrevWebhookMsges();
 });
 
 export async function discordBotInit() {


### PR DESCRIPTION
* only used when re-deploying to prevent multiple webhook messages from appearing

**IMPORTANT** earning speeds of all plots inspired by Excel sheet by **Lukas98 from discord (please credit him there when you deploy this)**, currently only displaying info for listed plots

![image](https://user-images.githubusercontent.com/13747131/152501176-103f91bb-c28b-4bc3-8f56-a8778648a9dd.png)